### PR TITLE
Change Snowflake Id into a singleton service.

### DIFF
--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClient.cs
@@ -21,6 +21,7 @@ namespace DotNetCore.CAP.AzureServiceBus
 
         private readonly ILogger _logger;
         private readonly string _subscriptionName;
+        private readonly IServiceProvider _serviceProvider;
         private readonly AzureServiceBusOptions _asbOptions;
 
         private ServiceBusAdministrationClient? _administrationClient;
@@ -30,11 +31,13 @@ namespace DotNetCore.CAP.AzureServiceBus
         public AzureServiceBusConsumerClient(
             ILogger logger,
             string subscriptionName,
-            IOptions<AzureServiceBusOptions> options)
+            IOptions<AzureServiceBusOptions> options,
+            IServiceProvider serviceProvider)
         {
             
             _logger = logger;
             _subscriptionName = subscriptionName;
+            _serviceProvider = serviceProvider;
             _asbOptions = options.Value ?? throw new ArgumentNullException(nameof(options));
         }
 

--- a/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClientFactory.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/AzureServiceBusConsumerClientFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Core Community. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+
 using DotNetCore.CAP.Transport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -11,13 +13,16 @@ namespace DotNetCore.CAP.AzureServiceBus
     {
         private readonly ILoggerFactory _loggerFactory;
         private readonly IOptions<AzureServiceBusOptions> _asbOptions;
+        private readonly IServiceProvider _serviceProvider;
 
         public AzureServiceBusConsumerClientFactory(
             ILoggerFactory loggerFactory,
-            IOptions<AzureServiceBusOptions> asbOptions)
+            IOptions<AzureServiceBusOptions> asbOptions,
+            IServiceProvider serviceProvider)
         {
             _loggerFactory = loggerFactory;
             _asbOptions = asbOptions;
+            _serviceProvider = serviceProvider;
         }
 
         public IConsumerClient Create(string groupId)
@@ -25,11 +30,11 @@ namespace DotNetCore.CAP.AzureServiceBus
             try
             {
                 var logger = _loggerFactory.CreateLogger(typeof(AzureServiceBusConsumerClient));
-                var client = new AzureServiceBusConsumerClient(logger, groupId, _asbOptions);
+                var client = new AzureServiceBusConsumerClient(logger, groupId, _asbOptions, _serviceProvider);
                 client.ConnectAsync().GetAwaiter().GetResult();
                 return client;
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 throw new BrokerConnectionException(e);
             }

--- a/src/DotNetCore.CAP.AzureServiceBus/CAP.AzureServiceBusOptions.cs
+++ b/src/DotNetCore.CAP.AzureServiceBus/CAP.AzureServiceBusOptions.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+
 using Azure.Messaging.ServiceBus;
+
 using DotNetCore.CAP.AzureServiceBus;
 using DotNetCore.CAP.AzureServiceBus.Producer;
+using DotNetCore.CAP.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace DotNetCore.CAP
@@ -63,12 +66,21 @@ namespace DotNetCore.CAP
         public Func<ServiceBusReceivedMessage, List<KeyValuePair<string, string>>>? CustomHeaders { get; set; }
 
         /// <summary>
+        /// Use this function to write additional headers from the original ASB Message or any Custom Header, i.e. to allow compatibility with heterogeneous systems, into <see cref="CapHeader"/>       
+        /// </summary>
+        /// <remarks>
+        /// This property is a copy cat of <see cref="CustomHeaders"/>. The difference is: It also accpets a <see cref="IServiceProvider"/> to use DI services.
+        /// This is added due to converting <see cref="SnowflakeId"/> into a singleton service.
+        /// </remarks>
+        public Func<ServiceBusReceivedMessage, IServiceProvider, List<KeyValuePair<string, string>>>? CustomHeadersBuilder { get; set; }
+
+        /// <summary>
         /// Custom SQL Filters for topic subscription , more about SQL Filters and its rules 
         /// Key: Rule Name , Value: SQL Expression 
         /// https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-sql-filter
         /// </summary>
-        public List<KeyValuePair<string,string>>? SQLFilters { get; set; }
-        
+        public List<KeyValuePair<string, string>>? SQLFilters { get; set; }
+
         public AzureServiceBusOptions ConfigureCustomProducer<T>(Action<ServiceBusProducerDescriptorBuilder<T>> configuration)
         {
             var builder = new ServiceBusProducerDescriptorBuilder<T>();

--- a/src/DotNetCore.CAP.InMemoryStorage/IDataStorage.InMemory.cs
+++ b/src/DotNetCore.CAP.InMemoryStorage/IDataStorage.InMemory.cs
@@ -7,11 +7,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
 using DotNetCore.CAP.Monitoring;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Serialization;
+
 using Microsoft.Extensions.Options;
 
 namespace DotNetCore.CAP.InMemoryStorage
@@ -20,11 +22,13 @@ namespace DotNetCore.CAP.InMemoryStorage
     {
         private readonly IOptions<CapOptions> _capOptions;
         private readonly ISerializer _serializer;
+        private readonly ISnowflakeId _snowflakeId;
 
-        public InMemoryStorage(IOptions<CapOptions> capOptions, ISerializer serializer)
+        public InMemoryStorage(IOptions<CapOptions> capOptions, ISerializer serializer, ISnowflakeId snowflakeId)
         {
             _capOptions = capOptions;
             _serializer = serializer;
+            _snowflakeId = snowflakeId;
         }
 
         public static ConcurrentDictionary<string, MemoryMessage> PublishedMessages { get; } = new();
@@ -99,7 +103,7 @@ namespace DotNetCore.CAP.InMemoryStorage
 
         public Task StoreReceivedExceptionMessageAsync(string name, string group, string content)
         {
-            var id = SnowflakeId.Default().NextId().ToString();
+            var id = _snowflakeId.NextId().ToString();
 
             ReceivedMessages[id] = new MemoryMessage
             {
@@ -121,7 +125,7 @@ namespace DotNetCore.CAP.InMemoryStorage
         {
             var mdMessage = new MediumMessage
             {
-                DbId = SnowflakeId.Default().NextId().ToString(),
+                DbId = _snowflakeId.NextId().ToString(),
                 Origin = message,
                 Added = DateTime.Now,
                 ExpiresAt = null,

--- a/src/DotNetCore.CAP.MongoDB/IDataStorage.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IDataStorage.MongoDB.cs
@@ -24,18 +24,21 @@ public class MongoDBDataStorage : IDataStorage
     private readonly IMongoDatabase _database;
     private readonly IOptions<MongoDBOptions> _options;
     private readonly ISerializer _serializer;
+    private readonly ISnowflakeId _snowflakeId;
 
     public MongoDBDataStorage(
         IOptions<CapOptions> capOptions,
         IOptions<MongoDBOptions> options,
         IMongoClient client,
-        ISerializer serializer)
+        ISerializer serializer,
+        ISnowflakeId snowflakeId)
     {
         _capOptions = capOptions;
         _options = options;
         _client = client;
         _database = _client.GetDatabase(_options.Value.DatabaseName);
         _serializer = serializer;
+        _snowflakeId = snowflakeId;
     }
 
     public async Task<bool> AcquireLockAsync(string key, TimeSpan ttl, string instance, CancellationToken token = default)
@@ -168,7 +171,7 @@ public class MongoDBDataStorage : IDataStorage
 
         var store = new ReceivedMessage
         {
-            Id = SnowflakeId.Default().NextId(),
+            Id = _snowflakeId.NextId(),
             Group = group,
             Name = name,
             Content = content,
@@ -186,7 +189,7 @@ public class MongoDBDataStorage : IDataStorage
     {
         var mdMessage = new MediumMessage
         {
-            DbId = SnowflakeId.Default().NextId().ToString(),
+            DbId = _snowflakeId.NextId().ToString(),
             Origin = message,
             Added = DateTime.Now,
             ExpiresAt = null,

--- a/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
+++ b/src/DotNetCore.CAP.MySql/IDataStorage.MySql.cs
@@ -26,6 +26,7 @@ public class MySqlDataStorage : IDataStorage
     private readonly string _pubName;
     private readonly string _recName;
     private readonly ISerializer _serializer;
+    private readonly ISnowflakeId _snowflakeId;
     private readonly bool _supportSkipLocked;
     private readonly string _lockName;
 
@@ -33,12 +34,14 @@ public class MySqlDataStorage : IDataStorage
         IOptions<MySqlOptions> options,
         IOptions<CapOptions> capOptions,
         IStorageInitializer initializer,
-        ISerializer serializer)
+        ISerializer serializer,
+        ISnowflakeId snowflakeId)
     {
         _options = options;
         _capOptions = capOptions;
         _initializer = initializer;
         _serializer = serializer;
+        _snowflakeId = snowflakeId;
         _pubName = initializer.GetPublishedTableName();
         _recName = initializer.GetReceivedTableName();
         _lockName = initializer.GetLockTableName();
@@ -158,7 +161,7 @@ public class MySqlDataStorage : IDataStorage
     {
         object[] sqlParams =
         {
-            new MySqlParameter("@Id", SnowflakeId.Default().NextId().ToString()),
+            new MySqlParameter("@Id", _snowflakeId.NextId().ToString()),
             new MySqlParameter("@Name", name),
             new MySqlParameter("@Group", group),
             new MySqlParameter("@Content", content),
@@ -175,7 +178,7 @@ public class MySqlDataStorage : IDataStorage
     {
         var mdMessage = new MediumMessage
         {
-            DbId = SnowflakeId.Default().NextId().ToString(),
+            DbId = _snowflakeId.NextId().ToString(),
             Origin = message,
             Added = DateTime.Now,
             ExpiresAt = null,

--- a/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
@@ -23,6 +23,7 @@ namespace DotNetCore.CAP.PostgreSql
         private readonly IStorageInitializer _initializer;
         private readonly IOptions<PostgreSqlOptions> _options;
         private readonly ISerializer _serializer;
+        private readonly ISnowflakeId _snowflakeId;
         private readonly string _pubName;
         private readonly string _recName;
         private readonly string _lockName;
@@ -31,12 +32,14 @@ namespace DotNetCore.CAP.PostgreSql
             IOptions<PostgreSqlOptions> options,
             IOptions<CapOptions> capOptions,
             IStorageInitializer initializer,
-            ISerializer serializer)
+            ISerializer serializer,
+            ISnowflakeId snowflakeId)
         {
             _capOptions = capOptions;
             _initializer = initializer;
             _options = options;
             _serializer = serializer;
+            _snowflakeId = snowflakeId;
             _pubName = initializer.GetPublishedTableName();
             _recName = initializer.GetReceivedTableName();
             _lockName = initializer.GetLockTableName();
@@ -151,7 +154,7 @@ namespace DotNetCore.CAP.PostgreSql
         {
             object[] sqlParams =
             {
-                new NpgsqlParameter("@Id", SnowflakeId.Default().NextId()),
+                new NpgsqlParameter("@Id", _snowflakeId.NextId()),
                 new NpgsqlParameter("@Name", name),
                 new NpgsqlParameter("@Group", group),
                 new NpgsqlParameter("@Content", content),
@@ -168,7 +171,7 @@ namespace DotNetCore.CAP.PostgreSql
         {
             var mdMessage = new MediumMessage
             {
-                DbId = SnowflakeId.Default().NextId().ToString(),
+                DbId = _snowflakeId.NextId().ToString(),
                 Origin = message,
                 Added = DateTime.Now,
                 ExpiresAt = null,

--- a/src/DotNetCore.CAP.SqlServer/IDataStorage.SqlServer.cs
+++ b/src/DotNetCore.CAP.SqlServer/IDataStorage.SqlServer.cs
@@ -26,18 +26,21 @@ public class SqlServerDataStorage : IDataStorage
     private readonly string _pubName;
     private readonly string _recName;
     private readonly ISerializer _serializer;
+    private readonly ISnowflakeId _snowflakeId;
     private readonly string _lockName;
 
     public SqlServerDataStorage(
         IOptions<CapOptions> capOptions,
         IOptions<SqlServerOptions> options,
         IStorageInitializer initializer,
-        ISerializer serializer)
+        ISerializer serializer,
+        ISnowflakeId snowflakeId)
     {
         _options = options;
         _initializer = initializer;
         _capOptions = capOptions;
         _serializer = serializer;
+        _snowflakeId = snowflakeId;
         _pubName = initializer.GetPublishedTableName();
         _recName = initializer.GetReceivedTableName();
         _lockName = initializer.GetLockTableName();
@@ -156,7 +159,7 @@ public class SqlServerDataStorage : IDataStorage
     {
         object[] sqlParams =
         {
-            new SqlParameter("@Id", SnowflakeId.Default().NextId().ToString()),
+            new SqlParameter("@Id", _snowflakeId.NextId().ToString()),
             new SqlParameter("@Name", name),
             new SqlParameter("@Group", group),
             new SqlParameter("@Content", content),
@@ -173,7 +176,7 @@ public class SqlServerDataStorage : IDataStorage
     {
         var mdMessage = new MediumMessage
         {
-            DbId = SnowflakeId.Default().NextId().ToString(),
+            DbId = _snowflakeId.NextId().ToString(),
             Origin = message,
             Added = DateTime.Now,
             ExpiresAt = null,

--- a/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
+++ b/src/DotNetCore.CAP/CAP.ServiceCollectionExtensions.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+
 using DotNetCore.CAP;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Processor;
 using DotNetCore.CAP.Serialization;
 using DotNetCore.CAP.Transport;
+
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 // ReSharper disable once CheckNamespace
@@ -29,7 +31,7 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton(_ => services);
         services.TryAddSingleton(new CapMarkerService("CAP"));
-
+        services.AddSingleton<ISnowflakeId>(_ => new SnowflakeId(Util.GenerateWorkerId(1023)));
         services.TryAddSingleton<ICapPublisher, CapPublisher>();
 
         services.TryAddSingleton<IConsumerServiceSelector, ConsumerServiceSelector>();

--- a/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
+++ b/src/DotNetCore.CAP/Internal/ICapPublisher.Default.cs
@@ -22,6 +22,7 @@ internal class CapPublisher : ICapPublisher
         new(CapDiagnosticListenerNames.DiagnosticListenerName);
 
     private readonly CapOptions _capOptions;
+    private readonly ISnowflakeId _snowflakeId;
     private readonly IDispatcher _dispatcher;
     private readonly IDataStorage _storage;
     private readonly IBootstrapper _bootstrapper;
@@ -33,6 +34,7 @@ internal class CapPublisher : ICapPublisher
         _dispatcher = service.GetRequiredService<IDispatcher>();
         _storage = service.GetRequiredService<IDataStorage>();
         _capOptions = service.GetRequiredService<IOptions<CapOptions>>().Value;
+        _snowflakeId = service.GetRequiredService<ISnowflakeId>();
         Transaction = new AsyncLocal<ICapTransaction>();
     }
 
@@ -112,7 +114,7 @@ internal class CapPublisher : ICapPublisher
 
         if (!headers.ContainsKey(Headers.MessageId))
         {
-            var messageId = SnowflakeId.Default().NextId().ToString();
+            var messageId = _snowflakeId.NextId().ToString();
             headers.Add(Headers.MessageId, messageId);
         }
 

--- a/src/DotNetCore.CAP/Internal/ISnowflakeId.cs
+++ b/src/DotNetCore.CAP/Internal/ISnowflakeId.cs
@@ -1,0 +1,10 @@
+﻿// Copyright 2010-2012 Twitter, Inc.
+// An object that generates IDs. This is broken into a separate class in case we ever want to support multiple worker threads per process
+
+namespace DotNetCore.CAP.Internal
+{
+    public interface ISnowflakeId
+    {
+        long NextId();
+    }
+}

--- a/test/DotNetCore.CAP.MySql.Test/ConnectionUtil.cs
+++ b/test/DotNetCore.CAP.MySql.Test/ConnectionUtil.cs
@@ -11,7 +11,7 @@ namespace DotNetCore.CAP.MySql.Test
         private const string DefaultDatabaseName = "cap_test";
 
         private const string DefaultConnectionString =
-            @"Server=localhost;Database=cap_test;Uid=root;Pwd=123123;Allow User Variables=True;SslMode=none;";
+            @"Server=localhost;Database=cap_test;Uid=root;Pwd=123123;Allow User Variables=True;SslMode=none;AllowPublicKeyRetrieval=true";
 
         public static string GetDatabaseName()
         {

--- a/test/DotNetCore.CAP.MySql.Test/MySqlStorageConnectionTest.cs
+++ b/test/DotNetCore.CAP.MySql.Test/MySqlStorageConnectionTest.cs
@@ -13,6 +13,7 @@ namespace DotNetCore.CAP.MySql.Test
     public class MySqlStorageConnectionTest : DatabaseTestHost
     {
         private readonly MySqlDataStorage _storage;
+        private ISnowflakeId _snowflakeId;
 
         public MySqlStorageConnectionTest()
         {
@@ -20,13 +21,14 @@ namespace DotNetCore.CAP.MySql.Test
             var options = GetService<IOptions<MySqlOptions>>();
             var capOptions = GetService<IOptions<CapOptions>>();
             var initializer = GetService<IStorageInitializer>();
-            _storage = new MySqlDataStorage(options, capOptions, initializer, serializer);
+            _snowflakeId = GetService<ISnowflakeId>();
+            _storage = new MySqlDataStorage(options, capOptions, initializer, serializer, _snowflakeId);
         }
 
         [Fact]
         public void StorageMessageTest()
         {
-            var msgId = SnowflakeId.Default().NextId().ToString();
+            var msgId = _snowflakeId.NextId().ToString();
             var header = new Dictionary<string, string>()
             {
                 [Headers.MessageId] = msgId
@@ -40,7 +42,7 @@ namespace DotNetCore.CAP.MySql.Test
         [Fact]
         public void StoreReceivedMessageTest()
         {
-            var msgId = SnowflakeId.Default().NextId().ToString();
+            var msgId = _snowflakeId.NextId().ToString();
             var header = new Dictionary<string, string>()
             {
                 [Headers.MessageId] = msgId
@@ -60,7 +62,7 @@ namespace DotNetCore.CAP.MySql.Test
         [Fact]
         public async Task ChangePublishStateTest()
         {
-            var msgId = SnowflakeId.Default().NextId().ToString();
+            var msgId = _snowflakeId.NextId().ToString();
             var header = new Dictionary<string, string>()
             {
                 [Headers.MessageId] = msgId
@@ -75,7 +77,7 @@ namespace DotNetCore.CAP.MySql.Test
         [Fact]
         public async Task ChangeReceiveStateTest()
         {
-            var msgId = SnowflakeId.Default().NextId().ToString();
+            var msgId = _snowflakeId.NextId().ToString();
             var header = new Dictionary<string, string>()
             {
                 [Headers.MessageId] = msgId

--- a/test/DotNetCore.CAP.MySql.Test/TestHost.cs
+++ b/test/DotNetCore.CAP.MySql.Test/TestHost.cs
@@ -1,4 +1,6 @@
 using System;
+
+using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Serialization;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,6 +40,7 @@ namespace DotNetCore.CAP.MySql.Test
             services.AddSingleton<MySqlDataStorage>();            
             services.AddSingleton<IStorageInitializer,MySqlStorageInitializer>();
             services.AddSingleton<ISerializer, JsonUtf8Serializer>();
+            services.AddSingleton<ISnowflakeId>(e => new SnowflakeId(10));
             _services = services;
         }
 

--- a/test/DotNetCore.CAP.Test/SnowflakeIdTest.cs
+++ b/test/DotNetCore.CAP.Test/SnowflakeIdTest.cs
@@ -8,10 +8,17 @@ namespace DotNetCore.CAP.Test
 {
     public class SnowflakeIdTest
     {
+        ISnowflakeId _snowflakeId;
+
+        public SnowflakeIdTest()
+        {
+            _snowflakeId = new SnowflakeId(Util.GenerateWorkerId(1023));
+        }
+
         [Fact]
         public void NextIdTest()
         {
-            var instance = SnowflakeId.Default();
+            var instance = _snowflakeId;
             var result = instance.NextId();
             var result2 = instance.NextId();
 
@@ -25,7 +32,7 @@ namespace DotNetCore.CAP.Test
 
             Parallel.For(0, 1000, i =>
             {
-                var id = SnowflakeId.Default().NextId();
+                var id = _snowflakeId.NextId();
                 array[i] = id;
             });
 

--- a/test/DotNetCore.CAP.Test/SubscribeInvokerTest.cs
+++ b/test/DotNetCore.CAP.Test/SubscribeInvokerTest.cs
@@ -20,6 +20,7 @@ namespace DotNetCore.CAP.Test
             serviceCollection.AddLogging();
             serviceCollection.AddSingleton<ISerializer, JsonUtf8Serializer>();
             serviceCollection.AddSingleton<ISubscribeInvoker, SubscribeInvoker>();
+            serviceCollection.AddSingleton<ISnowflakeId>(r => new SnowflakeId(Util.GenerateWorkerId(1023)));
             _serviceProvider = serviceCollection.BuildServiceProvider();
         }
 
@@ -28,6 +29,7 @@ namespace DotNetCore.CAP.Test
         [Fact]
         public async Task InvokeTest()
         {
+            var snowflakeId = _serviceProvider.GetRequiredService<ISnowflakeId>();
             var descriptor = new ConsumerExecutorDescriptor()
             {
                 Attribute = new CandidatesTopic("fake.output.integer"),
@@ -39,7 +41,7 @@ namespace DotNetCore.CAP.Test
 
             var header = new Dictionary<string, string>()
             {
-                [Headers.MessageId] = SnowflakeId.Default().NextId().ToString(),
+                [Headers.MessageId] = snowflakeId.NextId().ToString(),
                 [Headers.MessageName] = "fake.output.integer"
             };
             var message = new Message(header, null);

--- a/test/DotNetCore.CAP.Test/SubscribeInvokerWithCancellation.cs
+++ b/test/DotNetCore.CAP.Test/SubscribeInvokerWithCancellation.cs
@@ -22,6 +22,7 @@ namespace DotNetCore.CAP.Test
             serviceCollection.AddSingleton<IBootstrapper, Bootstrapper>();
             serviceCollection.AddSingleton<ISerializer, JsonUtf8Serializer>();
             serviceCollection.AddSingleton<ISubscribeInvoker, SubscribeInvoker>();
+            serviceCollection.AddSingleton<ISnowflakeId>(r => new SnowflakeId(Util.GenerateWorkerId(1023)));
             _serviceProvider = serviceCollection.BuildServiceProvider();
         }
 
@@ -30,6 +31,7 @@ namespace DotNetCore.CAP.Test
         [Fact]
         public async Task InvokeTest()
         {
+            var snowflakeId = _serviceProvider.GetRequiredService<ISnowflakeId>();
             var descriptor = new ConsumerExecutorDescriptor()
             {
                 Attribute = new CandidatesTopic("fake.output.withcancellation"),
@@ -49,7 +51,7 @@ namespace DotNetCore.CAP.Test
 
             var header = new Dictionary<string, string>()
             {
-                [Headers.MessageId] = SnowflakeId.Default().NextId().ToString(),
+                [Headers.MessageId] = snowflakeId.NextId().ToString(),
                 [Headers.MessageName] = "fake.output.withcancellation"
             };
             var message = new Message(header, null);


### PR DESCRIPTION
### Description:
Converts `SnowflakeId` from a singleton object into a singleton service that can be altered by the users.

#### Issue(s) addressed:
- #1322

#### Changes:
- It might introduce a breaking change if someone is using the `SnowflakeId.Default()` method.


#### How to test:
- In the startup, after calling `AddCap` to register cap services a user can add a singleton service that implements `ISnowlakeId` implements to change how the cap message Ids are generated.

### Additional notes (optional):
_Provide any additional notes or context that may be relevant to the changes._

### Checklist:
- [ x] I have tested my changes locally
- [ ] I have added necessary documentation (if applicable)
- [x ] I have updated the relevant tests (if applicable)
- [ x] My changes follow the project's code style guidelines

### Reviewers:
- @yang-xiaodong
